### PR TITLE
Suppress broken links in old Checker Framework releases

### DIFF
--- a/bin/checklink-args.txt
+++ b/bin/checklink-args.txt
@@ -15,6 +15,9 @@
 # An archived copy of a since-removed document, which contains broken links.
 --exclude-docs http://homes.cs.washington.edu/~mernst/advice/agre-networking-on-the-network-20050814.html
 --exclude-docs http://types.cs.washington.edu/checker-framework/jdk-api/(javac|jdk)/
+# Old releases contain numerous broken links that are fixed in the current release
+--exclude-docs http://types.cs.washington.edu/checker-framework/releases/
+--exclude-docs http://types.cs.washington.edu/dev/checker-framework/releases/
 --exclude-docs http://types.cs.washington.edu/list-archives/
 --exclude-docs http://types.cs.washington.edu/sparta/release/versions/
 --exclude-docs https://groups.csail.mit.edu/pag/cert/


### PR DESCRIPTION
The old Checker Framework release directories contain numerous broken links that are fixed in the current release, so they should be suppressed.

Also, the link checker is reporting a broken link to a fragment that is valid. I tried adding the following but it didn't work - what is the right way to add it?
--suppress-fragment http://homes.cs.washington.edu/~mernst/pubs/pluggable-checkers-icse2011.pdf#page=3