### PR TITLE
Doclet dest

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -9,6 +9,7 @@ PLUME_DIR_DEFAULT := $(realpath $(dir $(lastword $(MAKEFILE_LIST)))..)
 
 PLUME_DIR ?= ${PLUME_DIR_DEFAULT}
 
+UNAME_S := $(shell uname -s)
 ifndef JAVA_HOME
   ifeq ($(UNAME_S),Darwin)
     JAVA_HOME := $(shell /usr/libexec/java_home)
@@ -20,10 +21,8 @@ ifndef JAVA_HOME
   I_set_JAVA_HOME := true
 endif
 
-
 TOOLS_JAR ?= ${JAVA_HOME}/lib/tools.jar
 
-UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
   READLINK_F := readlink
 else


### PR DESCRIPTION
This PR primarily adds the -d destination directory command-line argument to plume.OptionsDoclet. The behavior is: if command line is

    -outfile output.html -d build/docs

then the file is written to `build/docs/output.html`.  If no `-outfile` is given, then `-d` is ignored.

The rationale for this addition is that I am using the Gradle Java plugin Javadoc task for the Randoop build. The task insists on spitting out a `-d` regardless of whether it is needed or not, and there is no workaround.  (The task also spits out titles, but those are ignored when set to the empty string.)

Also, I moved the uname command in the java/Makefile so that setting JAVA_HOME works (on OS X).