### PR TITLE
Added MinLen to the list of annotations that the reformatter ignores.

### DIFF
--- a/bin/fixup-google-java-format.py
+++ b/bin/fixup-google-java-format.py
@@ -139,6 +139,7 @@ typeAnnotations = set([
     "MethodVal",
     "MethodValBottom",
     "min",
+    "MinLen",
     "mm",
     "mm2",
     "mol",


### PR DESCRIPTION
The reformatter is messing up the MinLen checker's tests. I'd like it to ignore MinLen lines.