### PR TITLE
Add a new plume-core.jar target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ java/lookup.jar
 java/lookup.txt
 java/plume.jar
 java/plume.tar.gz
+java/plume-core.jar
 java/src/plume/.javadoc-timestamp
 java/src/plume/MathMDE.java
 java/src/plume/WeakIdentityHashMap.java-JDK6

--- a/java/Makefile
+++ b/java/Makefile
@@ -437,9 +437,6 @@ plume.jar: ${JAVA_AND_CPP_FILES} lib
 	(cd jar-contents; find * -type f | ${PLUME_DIR}/bin/sort-directory-order > jar-contents.txt)
 # Temporarily commented out so that plume-lib can be built with Java 8;
 # but I need to find a good way to double-check most builds.
-# TODO: The above comment isn't clear - what has been commented out?
-# Should there be a version of verify-plume here that doesn't unpack
-# the files again? Neither of the verify-plume targets seems to be used.
 	(cd jar-contents; "${JAR}" cf ../plume.jar @jar-contents.txt)
 	rm -rf jar-contents
 
@@ -461,7 +458,7 @@ verify-plume.jar:
 ###
 
 # Files that depend on the jar files in java/lib and shouldn't be
-# included in plume-core
+# included in plume-core.
 PLUME_CORE_REMOVE = \
 	core-jar-contents/plume/ICalAvailable*.class \
 	core-jar-contents/plume/HtmlPrettyPrint*.class \

--- a/java/Makefile
+++ b/java/Makefile
@@ -224,7 +224,7 @@ clean-except-jar:
 # Remove most generated files.
 # The goal is to cause all code to be remade and and tests to be run.
 clean: clean-except-jar
-	rm -f plume.jar lookup.jar task_manager.jar
+	rm -f plume.jar plume-core.jar lookup.jar task_manager.jar
 
 very-clean: very_clean
 
@@ -394,7 +394,7 @@ ifeq "$(I_set_JAVA_HOME)" "true"
 	@echo "WARNING: JAVA_HOME is not set, assuming $(JAVA_HOME)"
 endif
 
-jar: checkenv plume.jar lookup.jar task_manager.jar
+jar: checkenv plume.jar plume-core.jar lookup.jar task_manager.jar
 
 # This should depend on all the included .jar files, too.
 plume.jar: ${JAVA_AND_CPP_FILES} lib

--- a/java/Makefile
+++ b/java/Makefile
@@ -437,6 +437,9 @@ plume.jar: ${JAVA_AND_CPP_FILES} lib
 	(cd jar-contents; find * -type f | ${PLUME_DIR}/bin/sort-directory-order > jar-contents.txt)
 # Temporarily commented out so that plume-lib can be built with Java 8;
 # but I need to find a good way to double-check most builds.
+# TODO: The above comment isn't clear - what has been commented out?
+# Should there be a version of verify-plume here that doesn't unpack
+# the files again? Neither of the verify-plume targets seems to be used.
 	(cd jar-contents; "${JAR}" cf ../plume.jar @jar-contents.txt)
 	rm -rf jar-contents
 
@@ -452,6 +455,33 @@ verify-plume-jar-classfile-version:
 # Ensure that plume.jar does not contain JDK 8 or 9 classfiles
 verify-plume.jar:
 	echo "TODO"
+
+###
+### build plume-core.jar file
+###
+
+# Files that depend on the jar files in java/lib and shouldn't be
+# included in plume-core
+PLUME_CORE_REMOVE = \
+	core-jar-contents/plume/ICalAvailable*.class \
+	core-jar-contents/plume/HtmlPrettyPrint*.class \
+	core-jar-contents/plume/TimeLimitProcess*.class \
+	core-jar-contents/plume/DeclarationAnnotations*.class \
+	core-jar-contents/plume/BCELUtil*.class \
+
+plume-core.jar: ${JAVA_AND_CPP_FILES} lib
+	$(MAKE) tools_jar_exists
+	$(MAKE) clean optionsdoc
+	$(MAKE) compile
+	-rm -rf core-jar-contents
+	mkdir core-jar-contents
+	mkdir core-jar-contents/plume
+	cp -p src/plume/*.class core-jar-contents/plume
+	rm ${PLUME_CORE_REMOVE}
+# Put contents in alphabetical order.
+	(cd core-jar-contents; find * -type f | ${PLUME_DIR}/bin/sort-directory-order > core-jar-contents.txt)
+	(cd core-jar-contents; "${JAR}" cf ../plume-core.jar @core-jar-contents.txt)
+	rm -rf core-jar-contents
 
 
 ###

--- a/java/Makefile
+++ b/java/Makefile
@@ -471,7 +471,7 @@ PLUME_CORE_REMOVE = \
 
 plume-core.jar: ${JAVA_AND_CPP_FILES} lib
 	$(MAKE) tools_jar_exists
-	$(MAKE) clean optionsdoc
+	$(MAKE) clean-except-jar optionsdoc
 	$(MAKE) compile
 	-rm -rf core-jar-contents
 	mkdir core-jar-contents

--- a/java/Makefile
+++ b/java/Makefile
@@ -435,8 +435,6 @@ plume.jar: ${JAVA_AND_CPP_FILES} lib
 	rm -rf jar-contents/meta-inf jar-contents/META-INF
 # Put contents in alphabetical order.
 	(cd jar-contents; find * -type f | ${PLUME_DIR}/bin/sort-directory-order > jar-contents.txt)
-# Temporarily commented out so that plume-lib can be built with Java 8;
-# but I need to find a good way to double-check most builds.
 	(cd jar-contents; "${JAR}" cf ../plume.jar @jar-contents.txt)
 	rm -rf jar-contents
 


### PR DESCRIPTION
This shrinks the Checker Framework checker.jar file from more than 17 MB to below 8 MB and avoids distributing many unrelated jar files.