### PR TITLE
Suppress Index Checker warning

### DIFF
--- a/java/src/plume/LimitedSizeIntSet.java
+++ b/java/src/plume/LimitedSizeIntSet.java
@@ -106,7 +106,9 @@ public class LimitedSizeIntSet implements Serializable, Cloneable {
     // https://tinyurl.com/cfissue/984 is fixed.
     int[] svalues = s.values;
     for (int i = 0; i < s.size(); i++) {
-      add(svalues[i]);
+      @SuppressWarnings("index") // svalues is always shorter than or equal to the length of s.size()
+      /*@IndexFor("svalues")*/ int index = i;
+      add(svalues[index]);
       if (repNulled()) {
         return; // optimization, not necessary for correctness
       }

--- a/java/src/plume/LimitedSizeIntSet.java
+++ b/java/src/plume/LimitedSizeIntSet.java
@@ -106,7 +106,8 @@ public class LimitedSizeIntSet implements Serializable, Cloneable {
     // https://tinyurl.com/cfissue/984 is fixed.
     int[] svalues = s.values;
     for (int i = 0; i < s.size(); i++) {
-      @SuppressWarnings("index") // svalues is always shorter than or equal to the length of s.size()
+      @SuppressWarnings(
+          "index") // svalues is always shorter than or equal to the length of s.size()
       /*@IndexFor("svalues")*/ int index = i;
       add(svalues[index]);
       if (repNulled()) {

--- a/java/src/plume/LimitedSizeIntSet.java
+++ b/java/src/plume/LimitedSizeIntSet.java
@@ -107,7 +107,7 @@ public class LimitedSizeIntSet implements Serializable, Cloneable {
     int[] svalues = s.values;
     for (int i = 0; i < s.size(); i++) {
       @SuppressWarnings(
-          "index") // svalues is always shorter than or equal to the length of s.size()
+          "index") // svalues is the internal rep of s, and s.size() <= s.values.length
       /*@IndexFor("svalues")*/ int index = i;
       add(svalues[index]);
       if (repNulled()) {


### PR DESCRIPTION
This PR suppresses the Index Checker warning that was introduced in 2ca49adf2d61afec33ea297d2e83fed41a1f62d1 when a change that I made earlier in mernst#34 (that I thought was correct, and which passed the tests) was removed.

The warning needs to be suppressed, for list/array interop reasons.