### PR TITLE
Remove upper bound annotations on indices for CharSequence

### DIFF
--- a/java/src/plume/StringBuilderDelimited.java
+++ b/java/src/plume/StringBuilderDelimited.java
@@ -74,9 +74,7 @@ public class StringBuilderDelimited implements Appendable, CharSequence {
 
   @Override
   public StringBuilderDelimited append(
-      /*@Nullable*/ CharSequence csq,
-      /*@IndexOrHigh("#1")*/ int start,
-      /*@IndexOrHigh("#1")*/ int end) {
+      /*@Nullable*/ CharSequence csq, /*@NonNegative*/ int start, /*@NonNegative*/ int end) {
     appendDelimiter();
     delegate.append(csq, start, end);
     return this;


### PR DESCRIPTION
This PR replaces #37, which was created from a wrong branch by mistake and had to be closed (sorry for that).

The PR typetools/checker-framework#1716 removes upper bound annotations from indices to `CharSequence`. (They are not needed because warnings are ignored when passing indices to `CharSequence` methods.)
This PR does the same thing in `StringBuilderDelimited` to avoid `override.param.invalid` warnings from the index checker.