### PR TITLE
Suppress warnings on return types in StringBuilderDelimited

### DIFF
--- a/java/src/plume/StringBuilderDelimited.java
+++ b/java/src/plume/StringBuilderDelimited.java
@@ -89,6 +89,7 @@ public class StringBuilderDelimited implements Appendable, CharSequence {
 
   /*@Pure*/
   @Override
+  @SuppressWarnings("upperbound:override.return.invalid") // mutable-length subclass of CharSequence
   public /*@NonNegative*/ int length(/*>>>@GuardSatisfied StringBuilderDelimited this*/) {
     return delegate.length();
   }
@@ -101,6 +102,7 @@ public class StringBuilderDelimited implements Appendable, CharSequence {
 
   /*@SideEffectFree*/
   @Override
+  @SuppressWarnings("samelen:override.return.invalid") // mutable-length subclass of CharSequence
   public String toString(/*>>>@GuardSatisfied StringBuilderDelimited this*/) {
     return delegate.toString();
   }


### PR DESCRIPTION
This PR fixes type-checking by the Index Checker with PR typetools/checker-framework#1764.
Annotations were added to return types of two methods in `CharSequence`, so that there are less false positives in code using `CharSequence`. However, it means that overriders of these methods should use the annotations as well. They do not make sense for mutable-length implementations, so they are not used and the warnings are suppressed.