### PR TITLE
Modify warning suppression so that both index and value are suppressed

### DIFF
--- a/java/src/plume/TestPlume.java
+++ b/java/src/plume/TestPlume.java
@@ -2209,7 +2209,7 @@ public final class TestPlume {
             }
           }
           @SuppressWarnings(
-              "index") // The IotaIterator only contains indexes for totals.length, and since chosen's elements are selected randomly from the IotaIterator, all of its elements are @IndexFor
+                  {"index", "value"}) // The IotaIterator only contains indexes for totals.length, and since chosen's elements are selected randomly from the IotaIterator, all of its elements are @IndexFor
           List</*@IndexFor("totals")*/ Integer> chosen =
               UtilMDE.randomElements(new IotaIterator(itor_size), i, r);
           for (int m = 0; m < chosen.size(); m++) {


### PR DESCRIPTION
This is required for this PR: [typetools#1774](https://github.com/typetools/checker-framework/pull/1774), which correctly handles generics in the Value Checker when interacting with the Index Checker, as detailed in [kelloggm#186](https://github.com/kelloggm/checker-framework/issues/186). It's required here since an `IndexFor` is added by the warning suppression, which the Value Checker expects to be an `IntRange(from = 0)`.