### PR TITLE
Change regexp patterns to glob patterns in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,6 @@ tests/sort-directory-order-test/lines1.output
 # Ignore Eclipse output
 bin-eclipse/
 
-syntax: regexp
-# Not a glob because it starts with # which looks like a comment.
-(.*/)?\#[^/]*\#$
-(.*/)?\.\#.*
-plume-lib-[0-9.]*.tar.gz
+\#*\#
+.\#*
+plume-lib-*.tar.gz


### PR DESCRIPTION
The .gitignore file contains a `syntax: regexp` section which comes from Mercurial and does not work in Git. It also triggers a bug in Eclipse.

This PR changes the regex patterns to glob patterns. They may not be exactly equivalent, but hopefully fulfill the purpose.